### PR TITLE
Make `asyncForEach` internal

### DIFF
--- a/Sources/WalletConnectUtils/Extensions/Sequence.swift
+++ b/Sources/WalletConnectUtils/Extensions/Sequence.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
 
-public extension Sequence {
+extension Sequence {
     func asyncForEach(_ operation: @escaping (Element) async throws -> Void) async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for element in self {


### PR DESCRIPTION
# Description

Makes the `asyncForEach` function in the `Sequence` extension internal instead of `public`. The function is only used internally in two private functions, so it doesn't need to be `public`. If it's public it can clash with extensions of the same name in any projects that use this library. 

It also isn't really the purpose of this library to be vending general purpose `Sequence` extensions.

## How Has This Been Tested?

No need to test, only used in 2 private functions internal to WC SDK.

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
